### PR TITLE
chore(ci): add jitsi-ts-nocheck step to CI workflow

### DIFF
--- a/.github/actions/prepare-node-deps/action.yaml
+++ b/.github/actions/prepare-node-deps/action.yaml
@@ -43,6 +43,13 @@ runs:
         node ./scripts/generate-assets.js
         echo "::endgroup::"
 
+    - name: ci/jitsi-ts-nocheck
+      shell: bash
+      run: |
+        echo "::group::jitsi-ts-nocheck"
+        node scripts/jitsi-ts-nocheck.js
+        echo "::endgroup::"
+
     - name: ci/import-compass-icon
       shell: bash
       env:


### PR DESCRIPTION
<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
3. Take a look at other repository specific documentation at https://developers.mattermost.com/contribute
-->

#### Summary

Add a script in `ci` that inserts `@ts-nocheck` at the top of all Jitsi files, since Jitsi repositories do not transpile their libraries to JavaScript, which causes many TypeScript errors.

<!--
A brief description of what this pull request does.
-->

<!--
If this pull request addresses a Help Wanted ticket or fixes a reported issue, please link the relevant GitHub issue, e.g.

  Fixes https://github.com/mattermost/mattermost-mobile/issues/XXXXX

Otherwise, link the JIRA ticket.
-->

<!--
If the PR includes UI changes, include screenshots/GIFs/Videos (for both iOS and Android if possible).
-->

#### Release Note
<!--
Add a release note for each of the following conditions:

* New features and improvements, including behavioural changes, UI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense. Newlines are stripped.

Example:

```release-note
Added a new config setting ServiceSettings.FooBar. Added a new column Foo to the Users table.
```

```release-note
NONE
```
-->

```release-note
chore(ci): add jitsi-ts-nocheck step to CI workflow
```
